### PR TITLE
Updated code to print proper command name

### DIFF
--- a/GasPot.py
+++ b/GasPot.py
@@ -311,7 +311,7 @@ while True:
 
                 if cmd in cmds:
                     target.write(str(datetime.datetime.utcnow().strftime('%m/%d/%Y %H:%M')) + \
-                        " - %s Command Attempt from: %s\n" % (cmds[cmd], addr[0]))
+                        " - %s Command Attempt from: %s\n" % (cmd, addr[0]))
                     conn.send(cmds[cmd]())
                 elif cmd.startswith("S6020"):
                     # change the tank name


### PR DESCRIPTION
Line No. 313 was printing function name with function address instead of command name.
Ex. 
10/27/2015 12:25 - <function I20100 at 0x7f60abc7f7d0> Command Attempt from: 127.0.0.1

I think the log should contain only command names:
Ex.
10/27/2015 12:18 - I20100 Command Attempt from: 127.0.0.1
