### PR TITLE
Fixed crashing after interacting with malformed connections

### DIFF
--- a/GasPot.py
+++ b/GasPot.py
@@ -285,8 +285,8 @@ while True:
             new_con.settimeout(30.0)
             active_sockets.append(new_con)
         else:
-            addr = conn.getpeername()
             try:
+                addr = conn.getpeername()
                 # get current time in UTC
                 TIME = datetime.datetime.utcnow()
                 # write out initial connection
@@ -422,6 +422,11 @@ while True:
                     # log what was entered
                     log("Attempt from: %s\n" % addr[0], log_destinations)
                     log("Command Entered %s\n" % response, log_destinations)
+            except OSError as OSerr:
+                print("Error in OS Call: {}".format(str(OSerr)))
+                active_sockets.remove(conn)
+                conn.close()
+                continue
             except Exception as e:
                 print('Unknown Error: {}'.format(str(e)))
                 raise


### PR DESCRIPTION
It was noted that NMAP'ing GasPot caused an error that stopped the script. This was because of an OSError that origination from "conn.getpeername()" which is a OS function wrapper. When performed on a malformed connection, such as that create by NMAP where there is no remote address in the connection tuple, the error would get caught in the unknown error exception and the script would end. 

addr = conn.getpeername() was moved into the try statement and an exception was added for OSError that clears the connection after failing to get peer name and continues that loop.